### PR TITLE
Add support for per-texture color and alpha

### DIFF
--- a/src/render/vita/SDL_render_vita.c
+++ b/src/render/vita/SDL_render_vita.c
@@ -469,13 +469,23 @@ VITA_RenderCopy(SDL_Renderer *renderer, SDL_Texture *texture,
 	//float scaleY = dstrect->h > srcrect->h ? (float)(dstrect->h/srcrect->h) : 1;
 	float scaleX = dstrect->w == srcrect->w ? 1 : (float)(dstrect->w/srcrect->w);
 	float scaleY = dstrect->h == srcrect->h ? 1 : (float)(dstrect->h/srcrect->h);
+	Uint8 r, g, b, a;
+    
+	SDL_GetTextureColorMod(texture, &r, &g, &b);
+	SDL_GetTextureAlphaMod(texture, &a);
 
 	StartDrawing(renderer);
 
 	VITA_SetBlendMode(renderer, renderer->blendMode);
 
-	vita2d_draw_texture_part_scale(vita_texture->tex, dstrect->x, dstrect->y,
-		srcrect->x, srcrect->y, srcrect->w, srcrect->h, scaleX, scaleY);
+	if(r == 255 && g == 255 && b == 255 && a == 255)
+	{
+		vita2d_draw_texture_part_scale(vita_texture->tex, dstrect->x, dstrect->y,
+			srcrect->x, srcrect->y, srcrect->w, srcrect->h, scaleX, scaleY);
+	} else {
+		vita2d_draw_texture_tint_part_scale(vita_texture->tex, dstrect->x, dstrect->y,
+			srcrect->x, srcrect->y, srcrect->w, srcrect->h, scaleX, scaleY, (a << 24) + (b << 16) + (g << 8) + r);
+	}
 
 	return 0;
 }


### PR DESCRIPTION
This makes values set by `SDL_SetTextureColorMod` and `SDL_SetTextureAlphaMod` render properly on a Vita. I'm no SDL master and I don't know how fast this is or whether it conforms to code standards. However, this change made my SDL game port render identically as on PC, both tinting and transparency effects, with no noticeable effect on performance.