### PR TITLE
Calling wait_rendering_done before freeing stuffs.

### DIFF
--- a/src/render/vita/SDL_render_vita.c
+++ b/src/render/vita/SDL_render_vita.c
@@ -604,6 +604,7 @@ VITA_RenderPresent(SDL_Renderer *renderer)
 		return;
 
 	vita2d_end_drawing();
+	vita2d_wait_rendering_done();
 	vita2d_swap_buffers();
 
 	data->displayListAvail = SDL_FALSE;
@@ -620,7 +621,8 @@ VITA_DestroyTexture(SDL_Renderer *renderer, SDL_Texture *texture)
 
 	if(vita_texture == 0)
 		return;
-
+	
+	vita2d_wait_rendering_done();
 	vita2d_free_texture(vita_texture->tex);
 	SDL_free(vita_texture);
 	texture->driverdata = NULL;


### PR DESCRIPTION
Solves a crash in OpenClaw.