### PR TITLE
SDL 1.2 touchpad support (mouse emulation)

### DIFF
--- a/src/audio/psp2/SDL_psp2audio.c
+++ b/src/audio/psp2/SDL_psp2audio.c
@@ -36,6 +36,7 @@
 
 #include <psp2/kernel/threadmgr.h>
 #include <psp2/audioout.h>
+#include "malloc.h"
 
 /* The tag name used by DUMMY audio */
 #define PSP2AUD_DRIVER_NAME         "psp2"

--- a/src/video/psp2/SDL_psp2events.c
+++ b/src/video/psp2/SDL_psp2events.c
@@ -32,11 +32,13 @@
 #include "SDL_psp2events_c.h"
 #include "SDL_psp2keyboard_c.h"
 #include "SDL_psp2mouse_c.h"
+#include "SDL_psp2touch.h"
 
 void PSP2_PumpEvents(_THIS)
 {
 	PSP2_PollKeyboard();
 	PSP2_PollMouse();
+	PSP2_PollTouch();
 }
 
 void PSP2_InitOSKeymap(_THIS)

--- a/src/video/psp2/SDL_psp2touch.c
+++ b/src/video/psp2/SDL_psp2touch.c
@@ -1,0 +1,128 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2017 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+#include <psp2/touch.h>
+#include "../../events/SDL_events_c.h"
+#include "SDL_psp2touch.h"
+
+
+SceTouchData touch_data_old;
+SceTouchData touch_data;
+SceTouchPanelInfo panelinfo;
+float dispWidth;
+float dispHeight;
+Uint8 firstTouchId;
+
+
+void PSP2_InitTouch(void)
+{
+	sceTouchSetSamplingState(SCE_TOUCH_PORT_FRONT, SCE_TOUCH_SAMPLING_STATE_START);
+	sceTouchGetPanelInfo(SCE_TOUCH_PORT_FRONT, &panelinfo);
+	dispWidth = (float)(panelinfo.maxDispX - panelinfo.minDispX);
+	dispHeight = (float)(panelinfo.maxDispY - panelinfo.minDispY);
+}
+
+void PSP2_PollTouch(void)
+{
+	Sint16 x;
+	Sint16 y;
+	touch_data_old = touch_data;
+
+	sceTouchPeek(SCE_TOUCH_PORT_FRONT, &touch_data, 1);
+	if (touch_data.reportNum > 0)
+	{
+		// emulate mouse events only for 1st touch
+		if (touch_data_old.reportNum == 0)
+			firstTouchId = touch_data.report[0].id;
+
+		for (int i = 0; i < touch_data.reportNum; i++)
+		{
+			if (touch_data.report[i].id != firstTouchId)
+				continue;
+
+			PSP2_ConvertTouchXYToSDLXY(&x, &y, touch_data.report[i].x, touch_data.report[i].y);
+			SDL_PrivateMouseMotion(0, 0, x, y);
+
+			// LMB SDL_PRESSED on it's initial touch down
+			if (touch_data_old.reportNum == 0)
+			{
+				SDL_PrivateMouseButton(SDL_PRESSED, SDL_BUTTON_LEFT, x, y);
+			}
+			break;
+		}
+	}
+
+	// check for touch up
+	if (touch_data_old.reportNum > 0)
+	{
+		for (int i = 0; i < touch_data_old.reportNum; i++)
+		{
+			if (touch_data_old.report[i].id != firstTouchId)
+				continue;
+
+			int touch_up = 1;
+
+			if (touch_data.reportNum > 0)
+			{
+				for (int j = 0; j < touch_data.reportNum; j++)
+				{
+					if (touch_data.report[j].id == touch_data_old.report[i].id )
+					{
+						touch_up = 0;
+						break;
+					}
+				}
+			}
+
+			if (touch_up)
+			{
+				PSP2_ConvertTouchXYToSDLXY(&x, &y, touch_data_old.report[i].x, touch_data_old.report[i].y);
+				SDL_PrivateMouseButton(SDL_RELEASED, SDL_BUTTON_LEFT, x, y);
+			}
+
+			break;
+		}
+	}
+}
+
+void PSP2_ConvertTouchXYToSDLXY(Sint16 *sdl_x, Sint16 *sdl_y, Sint16 vita_x, Sint16 vita_y) 
+{
+	float x = (vita_x - panelinfo.minDispX) / dispWidth;
+	float y = (vita_y - panelinfo.minDispY) / dispHeight;
+
+	x = SDL_max(x, 0.0);
+	x = SDL_min(x, 1.0);
+	y = SDL_max(y, 0.0);
+	y = SDL_min(y, 1.0);
+
+	SDL_Rect surfaceRect;
+	SDL_Rect scaledRect;
+	PSP2_GetSurfaceRect(&surfaceRect, &scaledRect);
+
+	// translate to game coordinates
+	x = (SCREEN_W * x - scaledRect.x) * ((float)surfaceRect.w / scaledRect.w);
+	y = (SCREEN_H * y - scaledRect.y) * ((float)surfaceRect.h / scaledRect.h);
+
+	*sdl_x = x;
+	*sdl_y = y;
+}
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/src/video/psp2/SDL_psp2touch.h
+++ b/src/video/psp2/SDL_psp2touch.h
@@ -1,0 +1,34 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2017 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+#ifndef _SDL_vitatouch_h
+#define _SDL_vitatouch_h
+
+#include "SDL_psp2video.h"
+
+/* Touch functions */
+extern void PSP2_InitTouch(void);
+extern void PSP2_PollTouch(void);
+void PSP2_ConvertTouchXYToSDLXY(Sint16 *sdl_x, Sint16 *sdl_y, Sint16 vita_x, Sint16 vita_y);
+
+#endif /* _SDL_vitatouch_h */
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/src/video/psp2/SDL_psp2video.c
+++ b/src/video/psp2/SDL_psp2video.c
@@ -46,11 +46,9 @@
 #include "SDL_psp2events_c.h"
 #include "SDL_psp2mouse_c.h"
 #include "SDL_psp2keyboard_c.h"
+#include "SDL_psp2touch.h"
 
 #define PSP2VID_DRIVER_NAME "psp2"
-
-#define SCREEN_W 960
-#define SCREEN_H 544
 
 typedef struct private_hwdata {
 	vita2d_texture *texture;
@@ -152,6 +150,7 @@ int PSP2_VideoInit(_THIS, SDL_PixelFormat *vformat)
 
 	PSP2_InitKeyboard();
 	PSP2_InitMouse();
+	PSP2_InitTouch();
 
 	return(0);
 }
@@ -385,3 +384,25 @@ VideoBootStrap PSP2_bootstrap = {
 	PSP2_Available, PSP2_CreateDevice
 };
 
+void PSP2_GetSurfaceRect(SDL_Rect *surfaceRect, SDL_Rect *scaledRect)
+{
+	SDL_Surface *surface = SDL_VideoSurface;
+
+	surfaceRect->x = 0;
+	surfaceRect->y = 0;
+	surfaceRect->w = SCREEN_W;
+	surfaceRect->h = SCREEN_H;
+	scaledRect->x = 0;
+	scaledRect->y = 0;
+	scaledRect->w = SCREEN_W;
+	scaledRect->h = SCREEN_H;
+
+	if (surface != NULL && surface->hwdata != NULL)
+	{
+		surfaceRect->x = 0;
+		surfaceRect->y = 0;
+		surfaceRect->w = surface->w;
+		surfaceRect->h = surface->h;
+		*scaledRect = surface->hwdata->dst;
+	}
+}

--- a/src/video/psp2/SDL_psp2video.h
+++ b/src/video/psp2/SDL_psp2video.h
@@ -31,6 +31,10 @@
 /* Hidden "this" pointer for the video functions */
 #define _THIS	SDL_VideoDevice *this
 
+#define SCREEN_W 960
+#define SCREEN_H 544
+
+void PSP2_GetSurfaceRect(SDL_Rect *surfaceRect, SDL_Rect *scaledRect);
 
 /* Private display data */
 


### PR DESCRIPTION
Emulates LMB presses and mouse movement with front touchpad. Translates screen coordinates to game coordinates in the process (scaled/centered render area works fine).
Used it with GemRB port. Maybe someone else might find it useful too.